### PR TITLE
upgrade to scala 2.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ An ASCII-art diagram library for graphs. It supports both parsing existing diagr
 
 You can use it via sbt:
 
-    libraryDependencies += "com.github.mdr" %% "ascii-graphs" % "0.0.3"
+    libraryDependencies += "com.github.jlmauduy" %% "ascii-graphs" % "0.0.3"
 
 # Graph layout
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "ascii-graphs"
 
-organization := "com.github.mdr"
+organization := "com.github.jlmauduy"
 
 version := "0.0.7-SNAPSHOT"
 
@@ -41,7 +41,7 @@ publishTo <<= isSnapshot(
 
 pomExtra := {
     <inceptionYear>2012</inceptionYear>
-    <url>http://github.com/mdr/ascii-graphs</url>
+    <url>http://github.com/jlmauduy/ascii-graphs</url>
     <licenses>
       <license>
         <name>MIT License</name>
@@ -50,8 +50,8 @@ pomExtra := {
       </license>
     </licenses>
     <scm>
-      <url>git@github.com:mdr/ascii-graphs.git</url>
-      <connection>scm:git:git@github.com:mdr/ascii-graphs</connection>
+      <url>git@github.com:jlmauduy/ascii-graphs.git</url>
+      <connection>scm:git:git@github.com:jlmauduy/ascii-graphs</connection>
     </scm>
     <developers>
       <developer>

--- a/build.sbt
+++ b/build.sbt
@@ -2,19 +2,19 @@ name := "ascii-graphs"
 
 organization := "com.github.mdr"
 
-version := "0.0.6"
+version := "0.0.7-SNAPSHOT"
 
-scalaVersion := "2.10.1"
+scalaVersion := "2.11.1"
 
-crossScalaVersions := Seq("2.9.1", "2.9.2", "2.10.1")
+crossScalaVersions := Seq("2.10.1", "2.11.0", "2.11.1")
 
 scalacOptions ++= Seq("-deprecation")
 
 javacOptions ++= Seq("-source", "1.6", "-target", "1.6")
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "1.9.1" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.6" % "test"
 
-libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.10.1" % "test"
+libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.11.4" % "test"
 
 // Screen-sized dependency graph:
 // libraryDependencies += "org.vert-x" % "vertx-core" % "1.3.1.final"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.3
+sbt.version=0.13.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.3")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 
 // addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4-SNAPSHOT")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.4.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.0.1")	
+addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.0")	

--- a/src/test/scala/com/github/mdr/ascii/diagram/parser/DiagramParserTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/diagram/parser/DiagramParserTest.scala
@@ -1,13 +1,12 @@
 package com.github.mdr.ascii.diagram.parser
 
-import org.scalatest.matchers.ShouldMatchers
-import org.scalatest.FlatSpec
+import org.scalatest.{ Matchers, FlatSpec }
 import com.github.mdr.ascii.diagram.Diagram
 import com.github.mdr.ascii.diagram.Box
 import com.github.mdr.ascii.util.Utils
 import scala.io.Source
 
-class GraphDiagramParserTest extends FlatSpec with ShouldMatchers {
+class GraphDiagramParserTest extends FlatSpec with Matchers {
 
   "Parser" should "parse labels" in {
 

--- a/src/test/scala/com/github/mdr/ascii/diagram/parser/Issue1DirectedEdgeNotParsedTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/diagram/parser/Issue1DirectedEdgeNotParsedTest.scala
@@ -1,11 +1,10 @@
 package com.github.mdr.ascii.diagram.parser
 
-import org.scalatest.matchers.ShouldMatchers
-import org.scalatest.FlatSpec
+import org.scalatest.{ Matchers, FlatSpec }
 import com.github.mdr.ascii.graph.Graph
 import com.github.mdr.ascii.diagram.Diagram
 
-class Issue1DirectedEdgeNotParsedTest extends FlatSpec with ShouldMatchers {
+class Issue1DirectedEdgeNotParsedTest extends FlatSpec with Matchers {
 
   "Parser" should "detect directed edge" in {
 

--- a/src/test/scala/com/github/mdr/ascii/graph/GraphGenerators.scala
+++ b/src/test/scala/com/github/mdr/ascii/graph/GraphGenerators.scala
@@ -1,13 +1,15 @@
 package com.github.mdr.ascii.graph
 
 import org.scalacheck._
-import org.scalacheck.Gen.Params
+import org.scalacheck.Gen.Parameters
 import scala.util.Random
 import com.github.mdr.ascii.layout.cycles.CycleRemover
 
 object GraphGenerators {
 
-  implicit val graphGen: Gen[Graph[String]] = Gen { p: Params ⇒ Some(RandomGraph.randomGraph(new Random(p.rng))) }
+  implicit val graphGen: Gen[Graph[String]] = Gen.parameterized[Graph[String]] {
+    p: Parameters ⇒ RandomGraph.randomGraph(new Random(p.rng.self))
+  }
 
   implicit val arbitraryGraph = Arbitrary(graphGen)
 

--- a/src/test/scala/com/github/mdr/ascii/graph/TopologicalSortSpecification.scala
+++ b/src/test/scala/com/github/mdr/ascii/graph/TopologicalSortSpecification.scala
@@ -2,7 +2,6 @@ package com.github.mdr.ascii.graph
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
-import org.scalacheck.Gen.Params
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Properties
 import org.scalacheck.Shrink

--- a/src/test/scala/com/github/mdr/ascii/graph/TopologicalSortTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/graph/TopologicalSortTest.scala
@@ -1,10 +1,9 @@
 package com.github.mdr.ascii.graph
 
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{ Matchers, FlatSpec }
 import org.scalatest.prop.Checkers
 
-class TopologicalSortTest extends FlatSpec with ShouldMatchers with Checkers {
+class TopologicalSortTest extends FlatSpec with Matchers with Checkers {
 
   check("""
          +-+   +-+ 

--- a/src/test/scala/com/github/mdr/ascii/layout/Issue3InfiniteLoopTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/Issue3InfiniteLoopTest.scala
@@ -1,11 +1,10 @@
 package com.github.mdr.ascii.layout
 
-import org.scalatest.matchers.ShouldMatchers
-import org.scalatest.FlatSpec
+import org.scalatest.{ Matchers, FlatSpec }
 import com.github.mdr.ascii.graph.Graph
 
 // https://github.com/mdr/ascii-graphs/issues/3
-class Issue3InfiniteLoopTest extends FlatSpec with ShouldMatchers {
+class Issue3InfiniteLoopTest extends FlatSpec with Matchers {
 
   "Layouter" should "not go into an infinite loop" in {
     val v = Set("1", "2", "3", "7", "9")

--- a/src/test/scala/com/github/mdr/ascii/layout/RoundTripTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/RoundTripTest.scala
@@ -1,11 +1,10 @@
 package com.github.mdr.ascii.layout
 
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{ Matchers, FlatSpec }
 import com.github.mdr.ascii.graph.Graph
 import com.github.mdr.ascii.layout.RoundTripSpecification._
 
-class RoundTripTest extends FlatSpec with ShouldMatchers {
+class RoundTripTest extends FlatSpec with Matchers {
 
   "Round trip" should ("not overwrite an arrow") in {
     checkRoundTrip(Graph.fromDiagram("""

--- a/src/test/scala/com/github/mdr/ascii/layout/cycles/CycleRemoverSpecification.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/cycles/CycleRemoverSpecification.scala
@@ -4,7 +4,6 @@ import scala.util.Random._
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
-import org.scalacheck.Gen.Params
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Properties
 import org.scalacheck.Shrink

--- a/src/test/scala/com/github/mdr/ascii/layout/cycles/CycleRemoverTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/cycles/CycleRemoverTest.scala
@@ -1,13 +1,11 @@
 package com.github.mdr.ascii.layout.cycles
 
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
-
+import org.scalatest.{ Matchers, FlatSpec }
 import com.github.mdr.ascii.graph.Graph
 import com.github.mdr.ascii.graph.GraphUtils
 import com.github.mdr.ascii.util.Utils
 
-class CycleRemoverTest extends FlatSpec with ShouldMatchers {
+class CycleRemoverTest extends FlatSpec with Matchers {
 
   check("""
          +-+   +-+ 

--- a/src/test/scala/com/github/mdr/ascii/layout/cycles/GraphReflowTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/cycles/GraphReflowTest.scala
@@ -1,12 +1,11 @@
 package com.github.mdr.ascii.layout.cycles
 
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{ Matchers, FlatSpec }
 
 import com.github.mdr.ascii.graph.Graph
 import com.github.mdr.ascii.util.Utils
 
-class GraphReflowTest extends FlatSpec with ShouldMatchers {
+class GraphReflowTest extends FlatSpec with Matchers {
 
   reflowingGraph("""
          +-+   +-+ 

--- a/src/test/scala/com/github/mdr/ascii/layout/layering/AssignLayersSpecification.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/layering/AssignLayersSpecification.scala
@@ -2,7 +2,6 @@ package com.github.mdr.ascii.layout.layering
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
-import org.scalacheck.Gen.Params
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Properties
 import org.scalacheck.Shrink

--- a/src/test/scala/com/github/mdr/ascii/layout/layering/CrossingCalculatorTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/layering/CrossingCalculatorTest.scala
@@ -1,14 +1,12 @@
 package com.github.mdr.ascii.layout.layering
 
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
-
+import org.scalatest.{ Matchers, FlatSpec }
 import com.github.mdr.ascii.graph.GraphUtils
 import com.github.mdr.ascii.graph.Graph
 import com.github.mdr.ascii.util.Utils
 import com.github.mdr.ascii.layout.cycles.CycleRemover
 
-class CrossingCalculatorTest extends FlatSpec with ShouldMatchers {
+class CrossingCalculatorTest extends FlatSpec with Matchers {
 
   // Note: layer ordering in test data is done alphabetically
 

--- a/src/test/scala/com/github/mdr/ascii/layout/layering/LongestDistanceToSinkSpecification.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/layering/LongestDistanceToSinkSpecification.scala
@@ -2,7 +2,6 @@ package com.github.mdr.ascii.layout.layering
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
-import org.scalacheck.Gen.Params
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Properties
 import org.scalacheck.Shrink

--- a/src/test/scala/com/github/mdr/ascii/layout/layering/LongestDistanceToSinkTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/layering/LongestDistanceToSinkTest.scala
@@ -1,12 +1,11 @@
 package com.github.mdr.ascii.layout.layering
 
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{ Matchers, FlatSpec }
 import com.github.mdr.ascii.graph.Graph
 import com.github.mdr.ascii.graph.GraphUtils
 import com.github.mdr.ascii.util.Utils
 
-class LongestDistanceToSinkTest extends FlatSpec with ShouldMatchers {
+class LongestDistanceToSinkTest extends FlatSpec with Matchers {
 
   distancesToSinks("""
          +-+   +-+   +-+ 

--- a/src/test/scala/com/github/mdr/ascii/util/QuadTreeTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/util/QuadTreeTest.scala
@@ -1,10 +1,9 @@
 package com.github.mdr.ascii.util
 
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{ Matchers, FlatSpec }
 import com.github.mdr.ascii.common._
 
-class QuadTreeTest extends FlatSpec with ShouldMatchers {
+class QuadTreeTest extends FlatSpec with Matchers {
 
   "A QuadTree" should "work with one element" in {
     val tree = new QuadTree[Region](Dimension(16, 16))


### PR DESCRIPTION
Minimum to compile under scala 2.11.1.
Dependencies and plugins have been updated. Some warnings due to deprecations in scalatest have been solved.