### PR TITLE
migration to scala 2.11.2 (supports 2.10.4), dropped support for 2.9.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/
 .project
 .classpath
 .idea*
+
+src/main/.DS_Store

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ You can use it via sbt:
 
 # Graph layout
 
-    import com.github.mdr.ascii.layout._
+    import com.github.mdr.ascii.graph.Graph
+    import com.github.mdr.ascii.layout.GraphLayout
 
     val graph = Graph(
       vertices = List(
@@ -19,7 +20,7 @@ You can use it via sbt:
         "V2" -> "V5",
         "V2" -> "V6"))
 
-    val ascii = Layouter.renderGraph(graph)
+    val ascii = GraphLayout.renderGraph(graph)
 
     println(ascii)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ An ASCII-art diagram library for graphs. It supports both parsing existing diagr
 
 You can use it via sbt:
 
-    libraryDependencies += "com.github.mdr" %% "ascii-graphs" % "0.0.3"
+    libraryDependencies += "com.github.mdr" %% "ascii-graphs" % "0.0.7"
 
 # Graph layout
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,20 +1,26 @@
+import AssemblyKeys._
+
+assemblySettings
+
 name := "ascii-graphs"
 
 organization := "com.github.mdr"
 
-version := "0.0.6"
+version := "0.0.7"
 
-scalaVersion := "2.10.1"
+scalaVersion := "2.11.2"
 
-crossScalaVersions := Seq("2.9.1", "2.9.2", "2.10.1")
+crossScalaVersions := Seq("2.10.4", "2.11.2")
 
-scalacOptions ++= Seq("-deprecation")
+scalacOptions ++= Seq("-optimize", "-Yinline-warnings", "-feature", "-deprecation")
 
-javacOptions ++= Seq("-source", "1.6", "-target", "1.6")
+javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "1.9.1" % "test"
+libraryDependencies ++= Seq()
 
-libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.10.1" % "test"
+libraryDependencies += ("org.scalatest" %% "scalatest" % "2.1.3" % "test")
+
+libraryDependencies += ("org.scalacheck" %% "scalacheck" % "1.11.5" % "test")
 
 // Screen-sized dependency graph:
 // libraryDependencies += "org.vert-x" % "vertx-core" % "1.3.1.final"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.3
+sbt.version=0.13.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,20 @@
+logLevel := Level.Warn
+
+resolvers += Resolver.url("artifactory", url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
+
+resolvers ++= Seq(
+  "Sonatype Snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
+  "Sonatype Releases" at "http://oss.sonatype.org/content/repositories/releases"
+)
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
+
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.3")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
-// addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4-SNAPSHOT")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.2")
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.4.0")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.0.1")	
+addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")

--- a/src/main/scala/com/github/mdr/ascii/util/Utils.scala
+++ b/src/main/scala/com/github/mdr/ascii/util/Utils.scala
@@ -1,5 +1,7 @@
 package com.github.mdr.ascii.util
 
+import java.net.URL
+
 import scala.annotation.tailrec
 import scala.io.Source
 
@@ -21,7 +23,9 @@ object Utils {
   }
 
   def adjacentPairs[T](xs: List[T]): List[(T, T)] = xs zip xs.drop(1)
+
   def adjacentTriples[T](xs: List[T]): List[(T, T, T)] = xs zip xs.drop(1) zip xs.drop(2) map { case ((x, y), z) ⇒ (x, y, z) }
+
   def adjacentPairsWithPreviousAndNext[T](xs: List[T]): List[(Option[T], T, T, Option[T])] =
     (None :: xs.init.map(Some(_))) zip xs zip xs.drop(1) zip (xs.drop(2).map(Some(_)) :+ None) map {
       case (((x, y), z), u) ⇒ (x, y, z, u)
@@ -53,8 +57,8 @@ object Utils {
   }
 
   def getResourceAsString(path: String): String = {
-    val inputStream = getClass.getResourceAsStream(path)
-    Source.fromInputStream(inputStream).getLines.mkString("\n")
+    val url: URL = getClass.getResource(path)
+    Source.fromURL(url, "utf-8").mkString
   }
 
   /**

--- a/src/test/scala/com/github/mdr/ascii/diagram/parser/DiagramParserTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/diagram/parser/DiagramParserTest.scala
@@ -1,13 +1,13 @@
 package com.github.mdr.ascii.diagram.parser
 
 import org.scalatest.matchers.ShouldMatchers
-import org.scalatest.FlatSpec
+import org.scalatest.{ Matchers, FlatSpec }
 import com.github.mdr.ascii.diagram.Diagram
 import com.github.mdr.ascii.diagram.Box
 import com.github.mdr.ascii.util.Utils
 import scala.io.Source
 
-class GraphDiagramParserTest extends FlatSpec with ShouldMatchers {
+class GraphDiagramParserTest extends FlatSpec with Matchers {
 
   "Parser" should "parse labels" in {
 

--- a/src/test/scala/com/github/mdr/ascii/graph/GraphGenerators.scala
+++ b/src/test/scala/com/github/mdr/ascii/graph/GraphGenerators.scala
@@ -1,13 +1,16 @@
 package com.github.mdr.ascii.graph
 
 import org.scalacheck._
-import org.scalacheck.Gen.Params
+import org.scalacheck.Gen.Parameters
 import scala.util.Random
 import com.github.mdr.ascii.layout.cycles.CycleRemover
 
 object GraphGenerators {
 
-  implicit val graphGen: Gen[Graph[String]] = Gen { p: Params ⇒ Some(RandomGraph.randomGraph(new Random(p.rng))) }
+  implicit val graphGen: Gen[Graph[String]] = Gen.parameterized {
+    p: Parameters ⇒
+      RandomGraph.randomGraph(p.rng)
+  }
 
   implicit val arbitraryGraph = Arbitrary(graphGen)
 

--- a/src/test/scala/com/github/mdr/ascii/graph/TopologicalSortSpecification.scala
+++ b/src/test/scala/com/github/mdr/ascii/graph/TopologicalSortSpecification.scala
@@ -1,12 +1,7 @@
 package com.github.mdr.ascii.graph
 
-import org.scalacheck.Arbitrary
-import org.scalacheck.Gen
-import org.scalacheck.Gen.Params
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Properties
-import org.scalacheck.Shrink
-import com.github.mdr.ascii.util.Utils
 import com.github.mdr.ascii.graph.GraphGenerators._
 import com.github.mdr.ascii.layout.cycles.CycleRemover
 

--- a/src/test/scala/com/github/mdr/ascii/graph/TopologicalSortTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/graph/TopologicalSortTest.scala
@@ -1,10 +1,10 @@
 package com.github.mdr.ascii.graph
 
-import org.scalatest.FlatSpec
+import org.scalatest.{ Matchers, FlatSpec }
 import org.scalatest.matchers.ShouldMatchers
 import org.scalatest.prop.Checkers
 
-class TopologicalSortTest extends FlatSpec with ShouldMatchers with Checkers {
+class TopologicalSortTest extends FlatSpec with Matchers with Checkers {
 
   check("""
          +-+   +-+ 

--- a/src/test/scala/com/github/mdr/ascii/layout/Issue3InfiniteLoopTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/Issue3InfiniteLoopTest.scala
@@ -1,11 +1,11 @@
 package com.github.mdr.ascii.layout
 
 import org.scalatest.matchers.ShouldMatchers
-import org.scalatest.FlatSpec
+import org.scalatest.{ Matchers, FlatSpec }
 import com.github.mdr.ascii.graph.Graph
 
 // https://github.com/mdr/ascii-graphs/issues/3
-class Issue3InfiniteLoopTest extends FlatSpec with ShouldMatchers {
+class Issue3InfiniteLoopTest extends FlatSpec with Matchers {
 
   "Layouter" should "not go into an infinite loop" in {
     val v = Set("1", "2", "3", "7", "9")

--- a/src/test/scala/com/github/mdr/ascii/layout/RoundTripTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/RoundTripTest.scala
@@ -1,11 +1,11 @@
 package com.github.mdr.ascii.layout
 
-import org.scalatest.FlatSpec
+import org.scalatest.{ Matchers, FlatSpec }
 import org.scalatest.matchers.ShouldMatchers
 import com.github.mdr.ascii.graph.Graph
 import com.github.mdr.ascii.layout.RoundTripSpecification._
 
-class RoundTripTest extends FlatSpec with ShouldMatchers {
+class RoundTripTest extends FlatSpec with Matchers {
 
   "Round trip" should ("not overwrite an arrow") in {
     checkRoundTrip(Graph.fromDiagram("""

--- a/src/test/scala/com/github/mdr/ascii/layout/cycles/CycleRemoverSpecification.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/cycles/CycleRemoverSpecification.scala
@@ -2,12 +2,8 @@ package com.github.mdr.ascii.layout.cycles
 
 import scala.util.Random._
 
-import org.scalacheck.Arbitrary
-import org.scalacheck.Gen
-import org.scalacheck.Gen.Params
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Properties
-import org.scalacheck.Shrink
 
 import com.github.mdr.ascii.graph.Graph
 import com.github.mdr.ascii.graph.GraphUtils

--- a/src/test/scala/com/github/mdr/ascii/layout/cycles/CycleRemoverTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/cycles/CycleRemoverTest.scala
@@ -1,13 +1,13 @@
 package com.github.mdr.ascii.layout.cycles
 
-import org.scalatest.FlatSpec
+import org.scalatest.{ Matchers, FlatSpec }
 import org.scalatest.matchers.ShouldMatchers
 
 import com.github.mdr.ascii.graph.Graph
 import com.github.mdr.ascii.graph.GraphUtils
 import com.github.mdr.ascii.util.Utils
 
-class CycleRemoverTest extends FlatSpec with ShouldMatchers {
+class CycleRemoverTest extends FlatSpec with Matchers {
 
   check("""
          +-+   +-+ 

--- a/src/test/scala/com/github/mdr/ascii/layout/cycles/GraphReflowTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/cycles/GraphReflowTest.scala
@@ -1,12 +1,12 @@
 package com.github.mdr.ascii.layout.cycles
 
-import org.scalatest.FlatSpec
+import org.scalatest.{ Matchers, FlatSpec }
 import org.scalatest.matchers.ShouldMatchers
 
 import com.github.mdr.ascii.graph.Graph
 import com.github.mdr.ascii.util.Utils
 
-class GraphReflowTest extends FlatSpec with ShouldMatchers {
+class GraphReflowTest extends FlatSpec with Matchers {
 
   reflowingGraph("""
          +-+   +-+ 

--- a/src/test/scala/com/github/mdr/ascii/layout/layering/AssignLayersSpecification.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/layering/AssignLayersSpecification.scala
@@ -1,11 +1,7 @@
 package com.github.mdr.ascii.layout.layering
 
-import org.scalacheck.Arbitrary
-import org.scalacheck.Gen
-import org.scalacheck.Gen.Params
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Properties
-import org.scalacheck.Shrink
 import com.github.mdr.ascii.graph.Graph
 import com.github.mdr.ascii.graph.GraphGenerators._
 import com.github.mdr.ascii.layout.cycles.CycleRemover

--- a/src/test/scala/com/github/mdr/ascii/layout/layering/CrossingCalculatorTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/layering/CrossingCalculatorTest.scala
@@ -1,6 +1,6 @@
 package com.github.mdr.ascii.layout.layering
 
-import org.scalatest.FlatSpec
+import org.scalatest.{ Matchers, FlatSpec }
 import org.scalatest.matchers.ShouldMatchers
 
 import com.github.mdr.ascii.graph.GraphUtils
@@ -8,7 +8,7 @@ import com.github.mdr.ascii.graph.Graph
 import com.github.mdr.ascii.util.Utils
 import com.github.mdr.ascii.layout.cycles.CycleRemover
 
-class CrossingCalculatorTest extends FlatSpec with ShouldMatchers {
+class CrossingCalculatorTest extends FlatSpec with Matchers {
 
   // Note: layer ordering in test data is done alphabetically
 

--- a/src/test/scala/com/github/mdr/ascii/layout/layering/LongestDistanceToSinkSpecification.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/layering/LongestDistanceToSinkSpecification.scala
@@ -1,15 +1,10 @@
 package com.github.mdr.ascii.layout.layering
 
-import org.scalacheck.Arbitrary
-import org.scalacheck.Gen
-import org.scalacheck.Gen.Params
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Properties
-import org.scalacheck.Shrink
 
 import com.github.mdr.ascii.graph.Graph
 import com.github.mdr.ascii.graph.GraphGenerators._
-import com.github.mdr.ascii.layout.cycles.CycleRemover
 
 object LongestDistanceToSinkSpecification extends Properties("LongestDistanceToSink") {
 

--- a/src/test/scala/com/github/mdr/ascii/layout/layering/LongestDistanceToSinkTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/layout/layering/LongestDistanceToSinkTest.scala
@@ -1,12 +1,12 @@
 package com.github.mdr.ascii.layout.layering
 
-import org.scalatest.FlatSpec
+import org.scalatest.{ Matchers, FlatSpec }
 import org.scalatest.matchers.ShouldMatchers
 import com.github.mdr.ascii.graph.Graph
 import com.github.mdr.ascii.graph.GraphUtils
 import com.github.mdr.ascii.util.Utils
 
-class LongestDistanceToSinkTest extends FlatSpec with ShouldMatchers {
+class LongestDistanceToSinkTest extends FlatSpec with Matchers {
 
   distancesToSinks("""
          +-+   +-+   +-+ 

--- a/src/test/scala/com/github/mdr/ascii/util/QuadTreeTest.scala
+++ b/src/test/scala/com/github/mdr/ascii/util/QuadTreeTest.scala
@@ -1,10 +1,10 @@
 package com.github.mdr.ascii.util
 
-import org.scalatest.FlatSpec
+import org.scalatest.{ Matchers, FlatSpec }
 import org.scalatest.matchers.ShouldMatchers
 import com.github.mdr.ascii.common._
 
-class QuadTreeTest extends FlatSpec with ShouldMatchers {
+class QuadTreeTest extends FlatSpec with Matchers {
 
   "A QuadTree" should "work with one element" in {
     val tree = new QuadTree[Region](Dimension(16, 16))


### PR DESCRIPTION
several changes such that tests pass, and the new API's are supported
bumped version to 0.0.7

works on my box (max os x 10.9.4)
